### PR TITLE
RSL-09-2 feat: position group selector

### DIFF
--- a/src/components/GroupSelector/GroupSelector.tsx
+++ b/src/components/GroupSelector/GroupSelector.tsx
@@ -25,33 +25,31 @@ export const GroupSelector: FC = () => {
 
   const classes = useStyles();
   return (
-    <Grid container item xs={12} className={classes.wrapper}>
-      <Paper
-        elevation={3}
-        style={{ color: `${colorText}` }}
-        className={classes.paperWrapper}
-      >
-        <Grid item xs={12}>
-          <Typography variant="subtitle1" className={classes.textPosition}>
-            Groups
-          </Typography>
-        </Grid>
+    <div className={classes.wrapper}>
+      <Paper elevation={3} style={{ color: `${colorText}` }}>
+        <Grid container className={classes.paperWrapper}>
+          <Grid item className={classes.titleWrapper}>
+            <Typography variant="subtitle1" className={classes.title}>
+              Groups
+            </Typography>
+          </Grid>
 
-        <Grid item xs={12} className={classes.buttonWrapper}>
-          <Grid container justify="center">
-            {arrayNumberOfPage.map((numberGroup: number) => (
-              <ButtonGroupSelector
-                key={numberGroup}
-                onChangeGroupHandler={() => changeGroup(numberGroup)}
-                isActivePage={numberGroup === groupNow}
-                color={LEVEL_COLORS[numberGroup]}
-              >
-                {numberGroup + 1}
-              </ButtonGroupSelector>
-            ))}
+          <Grid item className={classes.buttonWrapper}>
+            <Grid container justify="center" alignItems="center">
+              {arrayNumberOfPage.map((numberGroup: number) => (
+                <ButtonGroupSelector
+                  key={numberGroup}
+                  onChangeGroupHandler={() => changeGroup(numberGroup)}
+                  isActivePage={numberGroup === groupNow}
+                  color={LEVEL_COLORS[numberGroup]}
+                >
+                  {numberGroup + 1}
+                </ButtonGroupSelector>
+              ))}
+            </Grid>
           </Grid>
         </Grid>
       </Paper>
-    </Grid>
+    </div>
   );
 };

--- a/src/components/GroupSelector/GroupSelector.tsx
+++ b/src/components/GroupSelector/GroupSelector.tsx
@@ -2,15 +2,19 @@ import React, { FC } from 'react';
 import { COUNT_GROUPS } from 'appConstants/index';
 import { LEVEL_COLORS } from 'appConstants/colors';
 
-import { Grid, Paper, Typography } from '@material-ui/core';
+import { Grid, Paper, Typography, useTheme } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 import { setGroup } from 'modules/TextBookPage/actions';
 import { selectGroup } from 'store/commonState/selectors';
 import { LocStore } from 'services';
 import { ButtonGroupSelector } from './components';
-import { useStyles } from './styled';
+import { GroupSelectorStyled, useStyles } from './styled';
 
-export const GroupSelector: FC = () => {
+type GroupSelectorProps = {
+  isOpacity: boolean;
+};
+
+export const GroupSelector: FC<GroupSelectorProps> = ({ isOpacity }) => {
   const dispatch = useDispatch();
   const arrayNumberOfPage = Array.from({ length: COUNT_GROUPS }, (v, k) => k);
 
@@ -23,9 +27,11 @@ export const GroupSelector: FC = () => {
 
   const colorText = LEVEL_COLORS[groupNow];
 
-  const classes = useStyles();
+  const theme = useTheme();
+  const classes = useStyles({ theme, isOpacity });
+
   return (
-    <div className={classes.wrapper}>
+    <GroupSelectorStyled isOpacity={isOpacity}>
       <Paper elevation={3} style={{ color: `${colorText}` }}>
         <Grid container className={classes.paperWrapper}>
           <Grid item className={classes.titleWrapper}>
@@ -50,6 +56,6 @@ export const GroupSelector: FC = () => {
           </Grid>
         </Grid>
       </Paper>
-    </div>
+    </GroupSelectorStyled>
   );
 };

--- a/src/components/GroupSelector/components/ButtonGroupSelector/ButtonGroupSelector.tsx
+++ b/src/components/GroupSelector/components/ButtonGroupSelector/ButtonGroupSelector.tsx
@@ -4,7 +4,7 @@ import { useStyles } from './styled';
 
 type ButtonGroupSelectorProps = {
   isActivePage: boolean;
-  onChangeGroupHandler: Function;
+  onChangeGroupHandler: () => void;
   children: number;
   color: string;
 };

--- a/src/components/GroupSelector/components/ButtonGroupSelector/styled.ts
+++ b/src/components/GroupSelector/components/ButtonGroupSelector/styled.ts
@@ -28,8 +28,8 @@ export const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
       borderRadius: '50%',
     },
     [theme.breakpoints.down('xs')]: {
-      width: '32px',
-      height: '32px',
+      width: '37px',
+      height: '37px',
       fontSize: '14px',
       lineHeight: '14px',
       margin: '6px',
@@ -49,8 +49,8 @@ export const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
       colors: props.isActivePage ? 'default' : 'pointer',
     },
     [theme.breakpoints.down('xs')]: {
-      width: '44px',
-      height: '44px',
+      width: '48px',
+      height: '48px',
     },
   }),
 }));

--- a/src/components/GroupSelector/components/ButtonGroupSelector/styled.ts
+++ b/src/components/GroupSelector/components/ButtonGroupSelector/styled.ts
@@ -28,8 +28,8 @@ export const useStyles = makeStyles<Theme, StyleProps>((theme) => ({
       borderRadius: '50%',
     },
     [theme.breakpoints.down('xs')]: {
-      width: '37px',
-      height: '37px',
+      width: '35px',
+      height: '35px',
       fontSize: '14px',
       lineHeight: '14px',
       margin: '6px',

--- a/src/components/GroupSelector/styled.ts
+++ b/src/components/GroupSelector/styled.ts
@@ -11,7 +11,7 @@ export const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
 
     width: '72px',
-    margin: '95px auto 0',
+    margin: '0 auto',
     transition: '0.2s',
 
     // '&:hover': {
@@ -80,7 +80,7 @@ export const GroupSelectorStyled = styled.div<GroupSelectorWrapper>`
   align-items: center;
 
   width: 72px;
-  margin: 200px auto 0;
+  margin: 0 auto;
   transition: 0.2s;
   opacity: ${({ isOpacity }) => (isOpacity ? '0.3' : '1')};
 

--- a/src/components/GroupSelector/styled.ts
+++ b/src/components/GroupSelector/styled.ts
@@ -31,15 +31,11 @@ export const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     alignItems: 'center',
   },
-  textPosition: {
-    textAlign: 'center',
-    fontWeight: 600,
-  },
   paperWrapper: {
     padding: '5px',
     [theme.breakpoints.down('xs')]: {
       display: 'flex',
-      flexDirection: 'column',
+      flexDirection: 'row',
     },
   },
   buttonWrapper: {
@@ -47,4 +43,20 @@ export const useStyles = makeStyles((theme) => ({
       display: 'flex',
     },
   },
+  titleWrapper: {
+    margin: '0 auto',
+    [theme.breakpoints.down('xs')]: {
+      margin: 'auto 0',
+    },
+  },
+  title: {
+    transform: '',
+    [theme.breakpoints.down('xs')]: {
+      textAlign: 'center',
+      fontWeight: 400,
+      writingMode: 'vertical-lr',
+      transform: 'rotate(180deg)',
+    },
+  },
+  containerWrapper: {},
 }));

--- a/src/components/GroupSelector/styled.ts
+++ b/src/components/GroupSelector/styled.ts
@@ -1,17 +1,23 @@
 import { makeStyles } from '@material-ui/core/styles';
+import styled from 'styled-components/macro';
 
 export const useStyles = makeStyles((theme) => ({
   wrapper: {
     position: 'sticky',
-    top: '50%',
-    transform: 'translateY(-50%)',
+    top: '10px',
 
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
 
     width: '72px',
-    margin: '0 auto',
+    margin: '95px auto 0',
+    transition: '0.2s',
+
+    // '&:hover': {
+    //   opacity: '1',
+    //   }
+    // },
 
     [theme.breakpoints.down('xs')]: {
       position: 'none',
@@ -60,3 +66,32 @@ export const useStyles = makeStyles((theme) => ({
   },
   containerWrapper: {},
 }));
+
+type GroupSelectorWrapper = {
+  isOpacity: boolean;
+};
+
+export const GroupSelectorStyled = styled.div<GroupSelectorWrapper>`
+  position: sticky;
+  top: 10px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  width: 72px;
+  margin: 200px auto 0;
+  transition: 0.2s;
+  opacity: ${({ isOpacity }) => (isOpacity ? '0.3' : '1')};
+
+  &:hover {
+    opacity: 1;
+  }
+  @media (max-width: 600px) {
+    position: static;
+    top: 0;
+    width: 98%;
+    transform: none;
+    margin: 0;
+  }
+`;

--- a/src/components/Pagination/styled.tsx
+++ b/src/components/Pagination/styled.tsx
@@ -82,6 +82,7 @@ export const StyledPaginationContainer = styled.div<StyledPaginationContainerPro
   ${(props) => props.breakpoints.down('xs')} {
     .root {
       font-size: 1rem;
+      margin: 10px auto;
     }
 
     .page-item,

--- a/src/components/Pagination/styled.tsx
+++ b/src/components/Pagination/styled.tsx
@@ -30,7 +30,7 @@ export const StyledPaginationContainer = styled.div<StyledPaginationContainerPro
     margin: 0 8px;
     background: ${COLOR_LAYOUT_WHITE};
     border-radius: 10px;
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
     user-select: none;
     transition: color 0.3s;
 
@@ -77,18 +77,9 @@ export const StyledPaginationContainer = styled.div<StyledPaginationContainerPro
     .root {
       font-size: 1.2rem;
     }
-
-    .page-item,
-    .previous-page-item,
-    .next-page-item,
-    .break-item {
-      width: 32px;
-      height: 32px;
-      margin: 0 4px;
-    }
   }
 
-  ${(props) => props.breakpoints.down('sm')} {
+  ${(props) => props.breakpoints.down('xs')} {
     .root {
       font-size: 1rem;
     }
@@ -97,8 +88,8 @@ export const StyledPaginationContainer = styled.div<StyledPaginationContainerPro
     .previous-page-item,
     .next-page-item,
     .break-item {
-      width: 25px;
-      height: 25px;
+      width: 32px;
+      height: 32px;
     }
   }
 `;

--- a/src/modules/TextBookPage/TextBookPage.tsx
+++ b/src/modules/TextBookPage/TextBookPage.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Word } from 'types';
-import { Container, Grid } from '@material-ui/core';
-import { ErrorMessage, Loader, Pagination } from 'components';
+import { Container } from '@material-ui/core';
+import { ErrorMessage, Loader, NavGame, Pagination } from 'components';
 import { setPageTitle } from 'store/commonState/actions';
 import { GroupSelector } from 'components/GroupSelector';
 import { selectUser } from 'modules/Login/selectors';
@@ -71,28 +71,37 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
       {error && <ErrorMessage />}
       {hasContent ? (
         <div className={classes.contentWrapper}>
-          <Grid container>
-            <Grid item xs={12} sm={11} className={classes.mainGrid}>
+          <div className={classes.containerGrid}>
+            {/* <div className={classes.mainGrid}> */}
+            <div className={classes.paginationTop}>
               <Pagination
                 pageCount={30}
                 initialPage={page}
                 forcePage={page}
                 group={group}
               />
+            </div>
+            <div className={classes.gamesWrapper}>
+              <NavGame />
+            </div>
+            <div className={classes.mainGrid}>
               <WordList words={words} />
+            </div>
+            <div className={classes.sideGrid}>
+              <GroupSelector isOpacity={scroll > 200} />
+            </div>
+            <div className={classes.paginationBottom}>
               <Pagination
                 pageCount={30}
                 initialPage={page}
                 forcePage={page}
                 group={group}
               />
-            </Grid>
-            <Grid item xs={12} sm={1} className={classes.sideGrid}>
-              <GroupSelector isOpacity={scroll > 200} />
-            </Grid>
-          </Grid>
+            </div>
+          </div>
         </div>
       ) : (
+        // </div>
         <Loader />
       )}
     </Container>

--- a/src/modules/TextBookPage/TextBookPage.tsx
+++ b/src/modules/TextBookPage/TextBookPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Word } from 'types';
 import { Container, Grid } from '@material-ui/core';
@@ -25,6 +25,8 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
   const error = useSelector(selectTextBookError);
   const user = useSelector(selectUser);
 
+  const [scroll, setScroll] = useState(0);
+
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -38,6 +40,27 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
   useEffect(() => {
     dispatch(setPageTitle('TextBook'));
   }, [dispatch]);
+
+  useEffect(() => {
+    let lastKnownScrollPosition = scroll;
+    let ticking = false;
+
+    const handlerScroll = () => {
+      lastKnownScrollPosition = window.scrollY;
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setScroll(lastKnownScrollPosition);
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+
+    window.addEventListener('scroll', handlerScroll);
+    return () => {
+      window.removeEventListener('scroll', handlerScroll);
+    };
+  }, [scroll]);
 
   const classes = useStyles();
 
@@ -65,7 +88,7 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
               />
             </Grid>
             <Grid item xs={12} sm={1} className={classes.sideGrid}>
-              <GroupSelector />
+              <GroupSelector isOpacity={scroll > 200} />
             </Grid>
           </Grid>
         </div>

--- a/src/modules/TextBookPage/TextBookPage.tsx
+++ b/src/modules/TextBookPage/TextBookPage.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Word } from 'types';
-import { Button, Container, Paper, Grid } from '@material-ui/core';
+import { Container, Grid } from '@material-ui/core';
 import { ErrorMessage, Loader, Pagination } from 'components';
 import { setPageTitle } from 'store/commonState/actions';
 import { GroupSelector } from 'components/GroupSelector';
@@ -12,14 +12,7 @@ import {
   selectTextBookError,
   selectTextBookWords,
 } from './selectors';
-import {
-  loadUserAggregateWords,
-  loadUserDeletedWords,
-  loadUserDifficultWords,
-  loadWords,
-  setGroup,
-  setPage,
-} from './actions';
+import { loadUserAggregateWords, loadWords } from './actions';
 import { WordList } from './components';
 import { useStyles } from './styled';
 
@@ -48,91 +41,37 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
 
   const classes = useStyles();
 
-  const onUsualWords = () => {
-    dispatch(setPage(0));
-    dispatch(setGroup(0));
-    dispatch(loadUserAggregateWords(user.id, group, page));
-  };
-
-  const onDifficultWords = () => {
-    dispatch(setPage(0));
-    dispatch(setGroup(0));
-    dispatch(loadUserDifficultWords(user.id, group, page));
-  };
-  const onDeletedWords = () => {
-    dispatch(setPage(0));
-    dispatch(setGroup(0));
-    dispatch(loadUserDeletedWords(user.id, group, page));
-  };
-
   const hasContent = words && words.length;
 
   return (
-    <Grid container item className={classes.buttonGroup}>
-      <Grid item xs={12} md={11} sm={10}>
-        <Container>
-          <div>Type of Words: </div>
-          <Button
-            type="button"
-            color="primary"
-            variant="contained"
-            onClick={onUsualWords}
-          >
-            Usual Words
-          </Button>
-          <Button
-            variant="contained"
-            color="default"
-            type="button"
-            onClick={onDifficultWords}
-          >
-            Difficult words
-          </Button>
-          <Button
-            variant="contained"
-            color="secondary"
-            type="button"
-            onClick={onDeletedWords}
-          >
-            Deleted words
-          </Button>
-          <hr />
-
-          <div
-            style={{
-              paddingBottom: '8px',
-              minHeight: '200px',
-              position: 'relative',
-            }}
-          >
-            <>
-              {error && <ErrorMessage />}
-              {hasContent ? (
-                <>
-                  <Pagination
-                    pageCount={30}
-                    initialPage={page}
-                    forcePage={page}
-                    group={group}
-                  />
-                  <WordList words={words} />
-                  <Pagination
-                    pageCount={30}
-                    initialPage={page}
-                    forcePage={page}
-                    group={group}
-                  />
-                </>
-              ) : (
-                <Loader />
-              )}
-            </>
-          </div>
-        </Container>
-      </Grid>
-      <Grid item xs={12} md={1} sm={2}>
-        <GroupSelector />
-      </Grid>
-    </Grid>
+    <Container>
+      {error && <ErrorMessage />}
+      {hasContent ? (
+        <div className={classes.contentWrapper}>
+          <Grid container>
+            <Grid item xs={12} sm={11} className={classes.mainGrid}>
+              <Pagination
+                pageCount={30}
+                initialPage={page}
+                forcePage={page}
+                group={group}
+              />
+              <WordList words={words} />
+              <Pagination
+                pageCount={30}
+                initialPage={page}
+                forcePage={page}
+                group={group}
+              />
+            </Grid>
+            <Grid item xs={12} sm={1} className={classes.sideGrid}>
+              <GroupSelector />
+            </Grid>
+          </Grid>
+        </div>
+      ) : (
+        <Loader />
+      )}
+    </Container>
   );
 };

--- a/src/modules/TextBookPage/components/WordCard/styled.ts
+++ b/src/modules/TextBookPage/components/WordCard/styled.ts
@@ -10,7 +10,6 @@ type CardContainerType = {
 };
 export const CardContainer = styled.div<CardContainerType>`
   display: flex;
-  max-width: 832px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
   border-radius: 10px;
   padding: 24px;

--- a/src/modules/TextBookPage/components/WordsList/WordList.tsx
+++ b/src/modules/TextBookPage/components/WordsList/WordList.tsx
@@ -3,7 +3,6 @@ import { Word } from 'types';
 import { useSelector } from 'react-redux';
 import { selectTextBookGroup } from 'modules/TextBookPage/selectors';
 import { LEVEL_COLORS } from 'appConstants/colors';
-import { NavGame } from 'components';
 import { WordCard } from '../WordCard';
 import { WordListStyled } from './styled';
 import { NoWordsMessage } from './components';
@@ -19,8 +18,6 @@ export const WordList: FC<WordListProps> = ({ words }) => {
 
   return hasWords ? (
     <WordListStyled>
-      <NavGame />
-
       {words.map((word) => {
         const isDeleted = word.userWord?.difficulty === 'easy';
         const wordStatistics = word.userWord?.optional?.statistics;

--- a/src/modules/TextBookPage/components/WordsList/styled.ts
+++ b/src/modules/TextBookPage/components/WordsList/styled.ts
@@ -4,4 +4,5 @@ export const WordListStyled = styled.div`
   display: grid;
   justify-content: center;
   grid-gap: 32px;
+  width: 100%;
 `;

--- a/src/modules/TextBookPage/styled.ts
+++ b/src/modules/TextBookPage/styled.ts
@@ -6,4 +6,27 @@ export const useStyles = makeStyles((theme) => ({
       flexDirection: 'column-reverse',
     },
   },
+  containerGrid: {
+    flexDirection: 'row',
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+    },
+  },
+  mainGrid: {
+    order: 1,
+    [theme.breakpoints.down('xs')]: {
+      order: 2,
+    },
+  },
+  sideGrid: {
+    order: 2,
+    position: 'relative',
+    [theme.breakpoints.down('xs')]: {
+      order: 1,
+    },
+  },
+  contentWrapper: {
+    maxWidth: '1000px',
+    margin: '0 auto',
+  },
 }));

--- a/src/modules/TextBookPage/styled.ts
+++ b/src/modules/TextBookPage/styled.ts
@@ -7,26 +7,39 @@ export const useStyles = makeStyles((theme) => ({
     },
   },
   containerGrid: {
-    flexDirection: 'row',
+    display: 'grid',
+    gridTemplateColumns: '1fr 72px',
+    gridTemplateRows: '50px minmax(50px, max-content) 1fr 50px',
+    gridTemplateAreas: `"paginationTop paginationTop" "games games" "main groups" "paginationBottom paginationBottom"`,
+    gridGap: '32px',
+
     [theme.breakpoints.down('xs')]: {
-      flexDirection: 'column',
+      gridTemplateColumns: '1fr',
+      gridTemplateRows:
+        'minmax(50px, max-content) 35px minmax(50px, max-content) 1fr minmax(50px, max-content)',
+      gridTemplateAreas: `"groups" "paginationTop" "games" "main" "paginationBottom"`,
+      gridGap: '24px',
     },
   },
+  paginationTop: {
+    gridArea: 'paginationTop',
+  },
+  paginationBottom: {
+    gridArea: 'paginationBottom',
+  },
+  gamesWrapper: {
+    gridArea: 'games',
+  },
+
   mainGrid: {
-    order: 1,
-    [theme.breakpoints.down('xs')]: {
-      order: 2,
-    },
+    gridArea: 'main',
   },
   sideGrid: {
-    order: 2,
     position: 'relative',
-    [theme.breakpoints.down('xs')]: {
-      order: 1,
-    },
+    gridArea: 'groups',
   },
   contentWrapper: {
-    maxWidth: '1000px',
+    maxWidth: '936px',
     margin: '0 auto',
   },
 }));


### PR DESCRIPTION
Подкорректировал позицию боковой панельки переключения групп.
надпись группы на мобилке сместил в бок.

UDP:
Поменял положение панельки, теперь она начинается наравне с карточками (на полном экране. Когда панель игр становиться на 2 строки, то уже не попадает на начало).
При прокрутке к панели добавляется опасите, что бы не так броско было. При наведении опасити убирается.
Видео работы тут:
https://www.loom.com/share/72928ebd6c4940f297f4494887a7ee44

![image](https://user-images.githubusercontent.com/20399054/113206405-17ebeb00-9278-11eb-8af0-4dcd1210edaf.png)
![image](https://user-images.githubusercontent.com/20399054/113206466-2d611500-9278-11eb-9376-126636acbd2f.png)
