### PR TITLE
RSL-35 fix: correct style for menu item for unauthorized user

### DIFF
--- a/src/components/Layout/components/SideBar/components/SideNav/components/MenuItem/MenuItem.tsx
+++ b/src/components/Layout/components/SideBar/components/SideNav/components/MenuItem/MenuItem.tsx
@@ -36,7 +36,7 @@ export const MenuItem: FC<MenuItemProps> = ({
       exact={true}
       style={{
         textDecoration: 'none',
-        opacity: showNotAuthorized ? ' 1' : '0.5',
+        opacity: !showNotAuthorized && !userId ? '0.5' : '1',
       }}
       title={title}
     >


### PR DESCRIPTION
Closes: #64 
Поправил ситуацию, когда для авторизованых пользователей оставались полупрозрачные пункты меню.
![image](https://user-images.githubusercontent.com/20399054/113329944-e0884780-9326-11eb-802c-c25f19928aed.png)
![image](https://user-images.githubusercontent.com/20399054/113329990-eda53680-9326-11eb-817d-3847e53cf7b3.png)
