### PR TITLE
RSL-36 fix menu button and add dynamic setting isMobile

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,12 +1,13 @@
 import React, { FC } from 'react';
 import { useLocation } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import clsx from 'clsx';
 import { MOBILE_WIDTH } from 'appConstants';
 import { Header, Footer, SideBar } from './components';
 import { useStyles } from './styled';
 
 export const Layout: FC = ({ children }) => {
-  const isMobile = window.document.body.offsetWidth < MOBILE_WIDTH;
+  const isMobile = window.innerWidth < MOBILE_WIDTH;
 
   const classes = useStyles();
   const location = useLocation();
@@ -22,16 +23,12 @@ export const Layout: FC = ({ children }) => {
   return (
     <div className={classes.root}>
       <CssBaseline />
-      <Header open={open} handleDrawerOpen={handleDrawerOpen} />
       <SideBar open={open} handleDrawerClose={handleDrawerClose} />
-      <main className={classes.content}>
-        <div
-          className={classes.appBarSpacer}
-          style={{ marginBottom: '20px' }}
-        />
-        {children}
+      <div className={clsx(classes.container, isMobile)}>
+        <Header open={open} handleDrawerOpen={handleDrawerOpen} />
+        <main className={classes.content}>{children}</main>
         {!location.pathname.includes('games') && <Footer />}
-      </main>
+      </div>
     </div>
   );
 };

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,12 +2,12 @@ import React, { FC } from 'react';
 import { useLocation } from 'react-router-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import clsx from 'clsx';
-import { MOBILE_WIDTH } from 'appConstants';
+import { useIsMobile } from 'hooks/useIsMobile';
 import { Header, Footer, SideBar } from './components';
 import { useStyles } from './styled';
 
 export const Layout: FC = ({ children }) => {
-  const isMobile = window.innerWidth < MOBILE_WIDTH;
+  const isMobile = useIsMobile();
 
   const classes = useStyles();
   const location = useLocation();

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -24,7 +24,7 @@ export const Layout: FC = ({ children }) => {
     <div className={classes.root}>
       <CssBaseline />
       <SideBar open={open} handleDrawerClose={handleDrawerClose} />
-      <div className={clsx(classes.container, isMobile)}>
+      <div className={clsx(classes.container)}>
         <Header open={open} handleDrawerOpen={handleDrawerOpen} />
         <main className={classes.content}>{children}</main>
         {!location.pathname.includes('games') && <Footer />}

--- a/src/components/Layout/components/Header/Header.tsx
+++ b/src/components/Layout/components/Header/Header.tsx
@@ -1,11 +1,9 @@
 import React, { FC } from 'react';
 import clsx from 'clsx';
-import Toolbar from '@material-ui/core/Toolbar';
-import IconButton from '@material-ui/core/IconButton';
+import { Toolbar, IconButton, AppBar } from '@material-ui/core';
 import MenuIcon from '@material-ui/icons/Menu';
-import AppBar from '@material-ui/core/AppBar';
-import { MOBILE_WIDTH } from 'appConstants';
 import { useSelector } from 'react-redux';
+import { useIsMobile } from 'hooks/useIsMobile';
 import { selectUser } from 'modules/Login/selectors';
 import { PageTitle, UserInfoBlock, LoginModal } from './components';
 import { useStyles } from './styled';
@@ -16,7 +14,7 @@ type HeaderProps = {
 };
 
 export const Header: FC<HeaderProps> = ({ open, handleDrawerOpen }) => {
-  const isMobile = window.innerWidth < MOBILE_WIDTH;
+  const isMobile = useIsMobile();
   const user = useSelector(selectUser);
 
   const classes = useStyles();

--- a/src/components/Layout/components/Header/Header.tsx
+++ b/src/components/Layout/components/Header/Header.tsx
@@ -5,7 +5,6 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import AppBar from '@material-ui/core/AppBar';
 import { MOBILE_WIDTH } from 'appConstants';
-import { COLOR_LAYOUT_GRAY } from 'appConstants/colors';
 import { useSelector } from 'react-redux';
 import { selectUser } from 'modules/Login/selectors';
 import { PageTitle, UserInfoBlock, LoginModal } from './components';
@@ -17,7 +16,7 @@ type HeaderProps = {
 };
 
 export const Header: FC<HeaderProps> = ({ open, handleDrawerOpen }) => {
-  const isMobile = window.document.body.offsetWidth < MOBILE_WIDTH;
+  const isMobile = window.innerWidth < MOBILE_WIDTH;
   const user = useSelector(selectUser);
 
   const classes = useStyles();
@@ -28,14 +27,15 @@ export const Header: FC<HeaderProps> = ({ open, handleDrawerOpen }) => {
       className={clsx(classes.appBar, open && !isMobile && classes.appBarShift)}
       color="transparent"
     >
-      <Toolbar className={classes.toolbar}>
+      <Toolbar>
         <IconButton
-          edge="start"
-          color="inherit"
-          style={{ color: COLOR_LAYOUT_GRAY }}
           aria-label="open drawer"
           onClick={handleDrawerOpen}
-          className={clsx(classes.menuButton, open && classes.menuButtonHidden)}
+          className={clsx(
+            classes.menuButton,
+            !isMobile && open && classes.menuButtonHidden,
+            isMobile && classes.menuButtonMobile
+          )}
         >
           <MenuIcon />
         </IconButton>

--- a/src/components/Layout/components/Header/components/PageTitle/PageTitle.tsx
+++ b/src/components/Layout/components/Header/components/PageTitle/PageTitle.tsx
@@ -1,14 +1,17 @@
 import React, { FC } from 'react';
 import { useSelector } from 'react-redux';
-import { selectPageTitle } from 'store/commonState/selectors';
 import { Typography } from '@material-ui/core';
+import { selectPageTitle } from 'store/commonState/selectors';
+import { useStyles } from './styled';
 
 type PageTitleProps = {};
 
 export const PageTitle: FC<PageTitleProps> = () => {
   const title = useSelector(selectPageTitle);
+  const classes = useStyles();
+
   return (
-    <Typography variant="h4" component="h1">
+    <Typography variant="h4" component="h1" className={classes.title}>
       {title}
     </Typography>
   );

--- a/src/components/Layout/components/Header/components/PageTitle/styled.ts
+++ b/src/components/Layout/components/Header/components/PageTitle/styled.ts
@@ -5,5 +5,8 @@ export const useStyles = makeStyles((theme) => ({
     [theme.breakpoints.down('sm')]: {
       fontSize: '30px',
     },
+    [theme.breakpoints.down('xs')]: {
+      fontSize: '25px',
+    },
   },
 }));

--- a/src/components/Layout/components/Header/components/PageTitle/styled.ts
+++ b/src/components/Layout/components/Header/components/PageTitle/styled.ts
@@ -1,0 +1,9 @@
+import makeStyles from '@material-ui/core/styles/makeStyles';
+
+export const useStyles = makeStyles((theme) => ({
+  title: {
+    [theme.breakpoints.down('sm')]: {
+      fontSize: '30px',
+    },
+  },
+}));

--- a/src/components/Layout/components/Header/styled.ts
+++ b/src/components/Layout/components/Header/styled.ts
@@ -1,19 +1,21 @@
 import makeStyles from '@material-ui/core/styles/makeStyles';
-import { DRAWER_WIDTH } from 'appConstants';
-import { COLOR_LAYOUT_TEXT } from 'appConstants/colors';
+import {
+  COLOR_LAYOUT_DARKBLUE,
+  COLOR_LAYOUT_GRAY,
+  COLOR_LAYOUT_TEXT,
+} from 'appConstants/colors';
 
 export const useStyles = makeStyles((theme) => ({
-  toolbar: {
-    paddingRight: 24, // keep right padding when drawer closed
-  },
   toolbarIcon: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     padding: '0 8px',
+    overflow: 'hidden',
     ...theme.mixins.toolbar,
   },
   appBar: {
+    position: 'static',
     zIndex: theme.zIndex.drawer + 1,
     transition: theme.transitions.create(['width', 'margin'], {
       easing: theme.transitions.easing.sharp,
@@ -23,19 +25,28 @@ export const useStyles = makeStyles((theme) => ({
     boxShadow: 'none',
   },
   appBarShift: {
-    marginLeft: DRAWER_WIDTH,
-    width: `calc(100% - ${DRAWER_WIDTH}px)`,
     transition: theme.transitions.create(['width', 'margin'], {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,
     }),
   },
   menuButton: {
-    marginRight: 36,
-    marginLeft: -4,
+    position: 'fixed',
+    left: '20px',
+    zIndex: theme.zIndex.drawer + 1,
+    color: COLOR_LAYOUT_GRAY,
   },
   menuButtonHidden: {
     display: 'none',
+  },
+  menuButtonMobile: {
+    position: 'relative',
+    left: 0,
+    marginRight: `${theme.spacing()}px`,
+    color: COLOR_LAYOUT_DARKBLUE,
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
   },
   grow: {
     flexGrow: 1,

--- a/src/components/Layout/components/SideBar/SideBar.tsx
+++ b/src/components/Layout/components/SideBar/SideBar.tsx
@@ -3,8 +3,9 @@ import clsx from 'clsx';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Drawer from '@material-ui/core/Drawer';
-import { APP_NAME, MOBILE_WIDTH } from 'appConstants';
 import { Typography } from '@material-ui/core';
+import { APP_NAME } from 'appConstants';
+import { useIsMobile } from 'hooks/useIsMobile';
 import { SideNav } from './components';
 import { useStyles } from './styled';
 
@@ -14,8 +15,7 @@ type SidebarProps = {
 };
 
 export const SideBar: FC<SidebarProps> = ({ open, handleDrawerClose }) => {
-  const isMobile = window.innerWidth < MOBILE_WIDTH;
-
+  const isMobile = useIsMobile();
   const classes = useStyles();
 
   return (

--- a/src/components/Layout/components/SideBar/SideBar.tsx
+++ b/src/components/Layout/components/SideBar/SideBar.tsx
@@ -5,7 +5,6 @@ import CloseIcon from '@material-ui/icons/Close';
 import Drawer from '@material-ui/core/Drawer';
 import { APP_NAME, MOBILE_WIDTH } from 'appConstants';
 import { Typography } from '@material-ui/core';
-import { COLOR_LAYOUT_GRAY } from 'appConstants/colors';
 import { SideNav } from './components';
 import { useStyles } from './styled';
 
@@ -15,7 +14,7 @@ type SidebarProps = {
 };
 
 export const SideBar: FC<SidebarProps> = ({ open, handleDrawerClose }) => {
-  const isMobile = window.document.body.offsetWidth < MOBILE_WIDTH;
+  const isMobile = window.innerWidth < MOBILE_WIDTH;
 
   const classes = useStyles();
 
@@ -32,14 +31,16 @@ export const SideBar: FC<SidebarProps> = ({ open, handleDrawerClose }) => {
       }}
     >
       <div className={classes.toolbarIcon}>
-        {open && (
-          <>
-            <IconButton onClick={handleDrawerClose}>
-              <CloseIcon style={{ color: COLOR_LAYOUT_GRAY }} />
-            </IconButton>
-            <Typography variant="h5">{APP_NAME}</Typography>
-          </>
-        )}
+        <>
+          <IconButton
+            style={{ opacity: open ? 1 : 0 }}
+            className={classes.closeButton}
+            onClick={handleDrawerClose}
+          >
+            <CloseIcon />
+          </IconButton>
+          <Typography variant="h5">{APP_NAME}</Typography>
+        </>
       </div>
       <SideNav />
     </Drawer>

--- a/src/components/Layout/components/SideBar/styled.ts
+++ b/src/components/Layout/components/SideBar/styled.ts
@@ -8,8 +8,10 @@ export const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     justifyContent: 'flex-start',
     padding: '0 8px',
-    marginLeft: 12,
+    marginLeft: '12px',
+    marginRight: '12px',
     color: COLOR_LAYOUT_GRAY,
+    overflow: 'hidden',
     ...theme.mixins.toolbar,
   },
 
@@ -39,5 +41,9 @@ export const useStyles = makeStyles((theme) => ({
   },
   divided: {
     marginBottom: 20,
+  },
+  closeButton: {
+    color: COLOR_LAYOUT_GRAY,
+    marginRight: `${theme.spacing()}px`,
   },
 }));

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -16,6 +16,7 @@ export const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
     overflow: 'auto',
     paddingTop: `${theme.spacing(4)}px`,
+    paddingBottom: `${theme.spacing(4)}px`,
     [theme.breakpoints.down('md')]: {
       paddingTop: `${theme.spacing(3)}px`,
     },

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -4,12 +4,23 @@ export const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
   },
-  appBarSpacer: theme.mixins.toolbar,
+  container: {
+    width: '100%',
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+  },
   content: {
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
-    minHeight: '100vh',
     overflow: 'auto',
+    paddingTop: `${theme.spacing(4)}px`,
+    [theme.breakpoints.down('md')]: {
+      paddingTop: `${theme.spacing(3)}px`,
+    },
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: `${theme.spacing(2)}px`,
+    },
   },
 }));

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { MOBILE_WIDTH } from 'appConstants';
+
+export const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const callback = () => {
+      const isMobileWidth = window.innerWidth < MOBILE_WIDTH;
+      if (isMobile !== isMobileWidth) {
+        setIsMobile(isMobileWidth);
+      }
+    };
+
+    window.addEventListener('resize', callback);
+    return () => window.removeEventListener('resize', callback);
+  }, [isMobile]);
+
+  return isMobile;
+};

--- a/src/modules/TextBookPage/TextBookPage.tsx
+++ b/src/modules/TextBookPage/TextBookPage.tsx
@@ -124,7 +124,6 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
 
       <div
         style={{
-          paddingBottom: '8px',
           minHeight: '200px',
           position: 'relative',
         }}


### PR DESCRIPTION
Closes: #66 
Closes: #67 
Поправила layout чтобы иконка меню ездила вместе с ним, сделала  чтобы логотип в меню плавно заезжал при закрытии, поправила несколько стилей.

Вынесла isMobile в хук, теперь не нужно будет перезагружать страницу. Заменила в нем проверку body.offsetWidth на window.innerWidth, так как offsetWidth считал без скроллбара, из-за этого при открытии меню на мобильных экранах, когда убиралась прокрутка, меню начинало себя странно вести. 
Использование: 
![image](https://user-images.githubusercontent.com/64521658/113382839-2d056e80-938b-11eb-9430-e1cab0b6cded.png)
