### PR TITLE
RSL-48 fix: add the check loading userId for Dictionary

### DIFF
--- a/src/modules/DictionaryPage/DictionaryPage.tsx
+++ b/src/modules/DictionaryPage/DictionaryPage.tsx
@@ -2,20 +2,22 @@ import React, { FC, useEffect } from 'react';
 import { setPageTitle } from 'store/commonState/actions';
 import { Container, Paper } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
-import { NavGame, RedirectionModal } from 'components';
-import { selectUserId } from 'modules/Login/selectors';
+import { Loader, NavGame, RedirectionModal } from 'components';
+import { selectAuthLoadingStatus, selectUserId } from 'modules/Login/selectors';
 
 type DictionaryProps = {};
 
 export const DictionaryPage: FC<DictionaryProps> = () => {
   const dispatch = useDispatch();
   const userId = useSelector(selectUserId);
+  const isUserLoaded = useSelector(selectAuthLoadingStatus);
 
   useEffect(() => {
     dispatch(setPageTitle('DictionaryPage'));
   }, [dispatch]);
 
-  if (!userId) return <RedirectionModal />;
+  if (!userId && !isUserLoaded) return <RedirectionModal />;
+  if (!userId && isUserLoaded) return <Loader />;
 
   return (
     <Container>

--- a/src/modules/DictionaryPage/DictionaryPage.tsx
+++ b/src/modules/DictionaryPage/DictionaryPage.tsx
@@ -10,14 +10,14 @@ type DictionaryProps = {};
 export const DictionaryPage: FC<DictionaryProps> = () => {
   const dispatch = useDispatch();
   const userId = useSelector(selectUserId);
-  const isUserLoaded = useSelector(selectAuthLoadingStatus);
+  const isUserLoading = useSelector(selectAuthLoadingStatus);
 
   useEffect(() => {
     dispatch(setPageTitle('DictionaryPage'));
   }, [dispatch]);
 
-  if (!userId && !isUserLoaded) return <RedirectionModal />;
-  if (!userId && isUserLoaded) return <Loader />;
+  if (!userId && !isUserLoading) return <RedirectionModal />;
+  if (!userId && isUserLoading) return <Loader />;
 
   return (
     <Container>

--- a/src/modules/Login/actionConsts.ts
+++ b/src/modules/Login/actionConsts.ts
@@ -1,2 +1,4 @@
 export const SET_USER = 'SET_USER';
 export const SET_AUTH = 'SET_AUTH';
+export const SET_AUTH_ERROR = 'SET_AUTH_ERROR';
+export const SET_AUTH_LOADING = 'SET_AUTH_LOADING';

--- a/src/modules/Login/actions.ts
+++ b/src/modules/Login/actions.ts
@@ -2,8 +2,13 @@ import { Auth, StateMainPage, User } from 'types';
 import { database, LocStore } from 'services';
 import { Action } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { SET_USER, SET_AUTH } from './actionConsts';
-import { setGroup, setPage } from '../TextBookPage/actions';
+import { setGroup, setPage } from 'modules/TextBookPage/actions';
+import {
+  SET_USER,
+  SET_AUTH,
+  SET_AUTH_ERROR,
+  SET_AUTH_LOADING,
+} from './actionConsts';
 
 export const setUser = (payload: User) => ({
   type: SET_USER,
@@ -15,13 +20,32 @@ export const setAuth = (payload: Auth) => ({
   payload,
 });
 
+export const setAuthError = (payload: boolean) => ({
+  type: SET_AUTH_ERROR,
+  payload,
+});
+
+export const setAuthLoading = (payload: boolean) => ({
+  type: SET_AUTH_LOADING,
+  payload,
+});
+
 export const logInUser = (
   email: string,
   password: string
-): ThunkAction<void, Auth, unknown, Action<string>> => async (dispatch) =>
-  database.loginUser({ email, password }).then((user) => {
-    dispatch(setAuth(user));
-  });
+): ThunkAction<void, Auth, unknown, Action<string>> => async (dispatch) => {
+  dispatch(setAuthLoading(true));
+  database.loginUser({ email, password }).then(
+    (user) => {
+      dispatch(setAuth(user));
+      dispatch(setAuthLoading(false));
+    },
+    () => {
+      dispatch(setAuthLoading(false));
+      dispatch(setAuthError(true));
+    }
+  );
+};
 
 export const logOutUser = (): ThunkAction<
   void,
@@ -49,14 +73,25 @@ export const logOutUser = (): ThunkAction<
 
   dispatch(setUser(user));
   dispatch(setAuth(auth));
+  dispatch(setAuthLoading(false));
+  dispatch(setAuthError(false));
   LocStore.deleteUser();
 };
 
 export const loadUserInfoById = (
   id: string
-): ThunkAction<void, StateMainPage, unknown, Action<string>> => (dispatch) =>
-  database.getUserById(id).then((user: User) => {
-    if (user) {
-      dispatch(setUser(user));
+): ThunkAction<void, StateMainPage, unknown, Action<string>> => (dispatch) => {
+  dispatch(setAuthLoading(true));
+  database.getUserById(id).then(
+    (user: User) => {
+      if (user) {
+        dispatch(setUser(user));
+      }
+      dispatch(setAuthLoading(false));
+    },
+    () => {
+      dispatch(setAuthError(true));
+      dispatch(setAuthLoading(false));
     }
-  });
+  );
+};

--- a/src/modules/Login/loginReducer.ts
+++ b/src/modules/Login/loginReducer.ts
@@ -1,6 +1,11 @@
 import { Reducer } from 'redux';
 import { StateLogin } from 'types';
-import { SET_AUTH, SET_USER } from './actionConsts';
+import {
+  SET_AUTH,
+  SET_AUTH_ERROR,
+  SET_AUTH_LOADING,
+  SET_USER,
+} from './actionConsts';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Action = { type: string; payload: any };
@@ -20,6 +25,8 @@ export const loginState: StateLogin = {
     refreshToken: '',
     message: '',
   },
+  error: false,
+  loading: false,
 };
 
 export const loginReducer: Reducer<StateLogin, Action> = (
@@ -39,6 +46,17 @@ export const loginReducer: Reducer<StateLogin, Action> = (
         auth: action.payload,
       };
 
+    case SET_AUTH_LOADING:
+      return {
+        ...state,
+        loading: action.payload,
+      };
+
+    case SET_AUTH_ERROR:
+      return {
+        ...state,
+        error: action.payload,
+      };
     default:
       return state;
   }

--- a/src/modules/Login/selectors.ts
+++ b/src/modules/Login/selectors.ts
@@ -7,3 +7,8 @@ export const selectUserId = (state: State) => state.loginReducer.user.id;
 export const selectToken = (state: State) => state.loginReducer.auth.token;
 
 export const selectAuth = (state: State) => state.loginReducer.auth;
+
+export const selectAuthErrorStatus = (state: State) => state.loginReducer.error;
+
+export const selectAuthLoadingStatus = (state: State) =>
+  state.loginReducer.loading;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,8 @@ export type StateCommon = {
 export type StateLogin = {
   user: User;
   auth: Auth;
+  error: boolean;
+  loading: boolean;
 };
 
 export type StateMainPage = {};


### PR DESCRIPTION
Добавил проверку процесса загрузки информации о пользователе для страницы Словаря.
Ранее был момент, когда выскакивала модалка с запретом доступа. Я завел в стейте переменные для ошибок и для процесса загрузки и проверяю их при выводе компонентов на словаре. 
Пока данные о пользоватле не загружены выводится лоадер.
Если загрузка завершена, а данных пользователя не получено, то выводится предупреждение об ограничении доступа.
Проверить работу можно на медленном интернете перегрузившись на странице словаря. Сперва будет лоадер, а потом страница загрузиться.
А если "поломать" адрес доступа к базе, то можно проверить компонент редиректа.