### PR TITLE
RSL-30-1 Rearranged blocks on the page

### DIFF
--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -12,13 +12,16 @@ export const useStyles = makeStyles((theme) => ({
   },
   content: {
     flexGrow: 1,
-    paddingTop: `${theme.spacing(4)}px`,
-    paddingBottom: `${theme.spacing(4)}px`,
+    paddingTop: `${theme.spacing(5)}px`,
+    paddingBottom: `${theme.spacing(5)}px`,
     [theme.breakpoints.down('md')]: {
-      paddingTop: `${theme.spacing(3)}px`,
+      paddingTop: `${theme.spacing(4)}px`,
     },
     [theme.breakpoints.down('sm')]: {
-      paddingTop: `${theme.spacing(2)}px`,
+      paddingTop: `${theme.spacing(4)}px`,
+    },
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: `${theme.spacing(5)}px`,
     },
   },
   gamesContent: {

--- a/src/components/NavGame/components/GameItem/styled.ts
+++ b/src/components/NavGame/components/GameItem/styled.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components/macro';
 
 export const ItemContainer = styled.div`
   display: flex;
-  margin-top: 16px;
   padding: 8px 24px 8px 16px;
   align-items: center;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);

--- a/src/components/NavGame/styled.ts
+++ b/src/components/NavGame/styled.ts
@@ -2,13 +2,13 @@ import styled from 'styled-components/macro';
 
 export const NavContainer = styled.div`
   display: flex;
+  gap: 16px;
   flex-wrap: wrap;
-  margin: 0px -8px;
   justify-content: center;
 
   a {
     text-decoration: none;
     color: inherit;
-    padding: 0px 8px;
+    padding: 0 8px;
   }
 `;

--- a/src/components/Pagination/styled.tsx
+++ b/src/components/Pagination/styled.tsx
@@ -12,7 +12,7 @@ export const StyledPaginationContainer = styled.div<StyledPaginationContainerPro
     display: flex;
     justify-content: center;
     padding: 0;
-    margin: 32px auto;
+    margin: 0 auto;
     list-style: none;
     font-size: 1.4rem;
   }

--- a/src/modules/DictionaryPage/DictionaryPage.tsx
+++ b/src/modules/DictionaryPage/DictionaryPage.tsx
@@ -147,7 +147,10 @@ export const DictionaryPage: FC<DictionaryProps> = () => {
       )}
 
       <div className={classes.contentWrapper}>
-        <div className={classes.containerGrid}>
+        <div className={classes.containerGridDictionary}>
+          <div className={classes.gamesWrapper}>
+            <NavGame />
+          </div>
           <div className={classes.paginationTop}>
             <Pagination
               pageCount={pagesCount}
@@ -156,13 +159,12 @@ export const DictionaryPage: FC<DictionaryProps> = () => {
               group={group}
             />
           </div>
-          <div className={classes.gamesWrapper}>
+          <div className={classes.topicWrapper}>
             <Sections
               group={group}
               activeSection={wordSection}
               handlers={[onUsualWords, onDifficultWords, onDeletedWords]}
             />
-            <NavGame />
           </div>
           <div className={classes.mainGrid}>
             <WordList

--- a/src/modules/DictionaryPage/components/Sections/styled.ts
+++ b/src/modules/DictionaryPage/components/Sections/styled.ts
@@ -3,12 +3,11 @@ import styled from 'styled-components/macro';
 
 export const SectionsContainer = styled.div`
   display: flex;
-  justify-content: space-between;
-  max-width: 567px;
-  width: 100%;
-
   flex-wrap: wrap;
   justify-content: center;
+
+  width: 100%;
+  max-width: 567px;
   margin: 0 auto;
 
   @media (max-width: ${(props) => props.theme.breakpoints.values.md}px) {
@@ -22,16 +21,13 @@ export const Section = styled.div<{ active: boolean }>`
   display: flex;
   align-items: center;
   padding: 12px 24px 12px 16px;
-  margin-top: 16px;
-  margin-bottom: 16px;
   background-color: #ffffff;
   border-radius: 10px;
-  box-shadow: ${({ active }) =>
-    active ? '0px 0px 10px rgba(0, 0, 0, 0.15)' : ''};
+  box-shadow: ${({ active }) => (active ? '0 0 10px rgba(0, 0, 0, 0.15)' : '')};
 
   &:hover {
     cursor: pointer;
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
   }
 
   & + div {

--- a/src/modules/TextBookPage/TextBookPage.tsx
+++ b/src/modules/TextBookPage/TextBookPage.tsx
@@ -85,6 +85,9 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
       {hasContent ? (
         <div className={classes.contentWrapper}>
           <div className={classes.containerGrid}>
+            <div className={classes.gamesWrapper}>
+              <NavGame />
+            </div>
             <div className={classes.paginationTop}>
               <Pagination
                 pageCount={30}
@@ -92,9 +95,6 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
                 forcePage={page}
                 group={group}
               />
-            </div>
-            <div className={classes.gamesWrapper}>
-              <NavGame />
             </div>
             <div className={classes.mainGrid}>
               <WordList

--- a/src/modules/TextBookPage/styled.ts
+++ b/src/modules/TextBookPage/styled.ts
@@ -9,16 +9,32 @@ export const useStyles = makeStyles((theme) => ({
   containerGrid: {
     display: 'grid',
     gridTemplateColumns: '1fr 72px',
-    gridTemplateRows: '50px minmax(50px, max-content) 1fr 110px',
-    gridTemplateAreas: `"paginationTop paginationTop" "games games" "main groups" "paginationBottom paginationBottom"`,
-    gridGap: '32px',
+    gridTemplateRows: 'max-content max-content 1fr 110px',
+    gridTemplateAreas: `"games games" "paginationTop paginationTop"  "main groups" "paginationBottom paginationBottom"`,
+    gridRowGap: '32px',
+    gridColumnGap: '32px',
+
+    [theme.breakpoints.down('xs')]: {
+      gridTemplateColumns: '1fr',
+      gridTemplateRows: 'max-content max-content max-content 1fr max-content',
+      gridTemplateAreas: `"games" "groups" "paginationTop"  "main" "paginationBottom"`,
+      gridRowGap: '24px',
+    },
+  },
+  containerGridDictionary: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 72px',
+    gridTemplateRows: 'max-content max-content max-content 1fr 110px',
+    gridTemplateAreas: `"games games" "topics topics" "paginationTop paginationTop" "main groups" "paginationBottom paginationBottom"`,
+    gridRowGap: '32px',
+    gridColumnGap: '32px',
 
     [theme.breakpoints.down('xs')]: {
       gridTemplateColumns: '1fr',
       gridTemplateRows:
-        'minmax(50px, max-content) 35px minmax(50px, max-content) 1fr minmax(50px, max-content)',
-      gridTemplateAreas: `"groups" "paginationTop" "games" "main" "paginationBottom"`,
-      gridGap: '24px',
+        'max-content max-content max-content max-content 1fr max-content',
+      gridTemplateAreas: `"games" "topics" "groups" "paginationTop" "main" "paginationBottom"`,
+      gridRowGap: '24px',
     },
   },
   paginationTop: {
@@ -30,7 +46,9 @@ export const useStyles = makeStyles((theme) => ({
   gamesWrapper: {
     gridArea: 'games',
   },
-
+  topicWrapper: {
+    gridArea: 'topics',
+  },
   mainGrid: {
     gridArea: 'main',
   },


### PR DESCRIPTION
Closes: #95 
Перекомпоновал блоки на странице.
Поскольку все сделано теперь на гридах поубирал всякие лишние маржины в пагинации, в новагиции по играм и прочее. Теперь все разжвигается за счет `grid-gap`.
![image](https://user-images.githubusercontent.com/20399054/114071258-96b0db80-98a9-11eb-883b-7cf75b9b3c65.png)
![image](https://user-images.githubusercontent.com/20399054/114071297-a0d2da00-98a9-11eb-81b2-0820f332d1e9.png)
![image](https://user-images.githubusercontent.com/20399054/114071346-ae885f80-98a9-11eb-9fdc-519d53352d40.png)
