### PR TITLE
RSL-64 Optimize group selector

### DIFF
--- a/src/components/GroupSelector/styled.ts
+++ b/src/components/GroupSelector/styled.ts
@@ -88,5 +88,6 @@ export const GroupSelectorStyled = styled.div<GroupSelectorWrapper>`
     width: 98%;
     transform: none;
     margin: 0;
+    opacity: 1;
   }
 `;

--- a/src/hooks/useIsPageTopMatch.ts
+++ b/src/hooks/useIsPageTopMatch.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+export const useIsPageTopMatch = (minTop: number) => {
+  const [isMatch, setIsMatch] = useState(window.scrollY > minTop);
+
+  useEffect(() => {
+    const handlerScroll = () => {
+      if (window.scrollY > minTop) {
+        setIsMatch(true);
+      } else {
+        setIsMatch(false);
+      }
+    };
+
+    window.addEventListener('scroll', handlerScroll);
+    return () => {
+      window.removeEventListener('scroll', handlerScroll);
+    };
+  }, [minTop]);
+
+  return isMatch;
+};

--- a/src/hooks/useIsPageTopMatch.ts
+++ b/src/hooks/useIsPageTopMatch.ts
@@ -5,11 +5,7 @@ export const useIsPageTopMatch = (minTop: number) => {
 
   useEffect(() => {
     const handlerScroll = () => {
-      if (window.scrollY > minTop) {
-        setIsMatch(true);
-      } else {
-        setIsMatch(false);
-      }
+      setIsMatch(window.scrollY > minTop);
     };
 
     window.addEventListener('scroll', handlerScroll);

--- a/src/modules/DictionaryPage/DictionaryPage.tsx
+++ b/src/modules/DictionaryPage/DictionaryPage.tsx
@@ -4,6 +4,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
 import { StateTextBook, Word, WordSectionType } from 'types';
 import { Container } from '@material-ui/core';
+import { useIsPageTopMatch } from 'hooks/useIsPageTopMatch';
 import { LocStore } from 'services';
 import {
   ErrorMessage,
@@ -72,7 +73,7 @@ export const DictionaryPage: FC<DictionaryProps> = () => {
 
   const userId = useSelector(selectUserId);
   const isUserLoading = useSelector(selectAuthLoadingStatus);
-  const [scroll, setScroll] = useState(0);
+  const isGroupSelectorHidden = useIsPageTopMatch(200);
   const classes = useStyles();
   const [gettingGameWords, setGettingGameWords] = useState(false);
   const [checkPageForGameWords, setCheckPageForGameWords] = useState(-1);
@@ -130,27 +131,6 @@ export const DictionaryPage: FC<DictionaryProps> = () => {
       );
     }
   }, [dispatch, pagesCount]);
-
-  useEffect(() => {
-    let lastKnownScrollPosition = scroll;
-    let ticking = false;
-
-    const handlerScroll = () => {
-      lastKnownScrollPosition = window.scrollY;
-      if (!ticking) {
-        window.requestAnimationFrame(() => {
-          setScroll(lastKnownScrollPosition);
-          ticking = false;
-        });
-        ticking = true;
-      }
-    };
-
-    window.addEventListener('scroll', handlerScroll);
-    return () => {
-      window.removeEventListener('scroll', handlerScroll);
-    };
-  }, [scroll]);
 
   useEffect(() => {
     dispatch(setGameWords(words));
@@ -289,7 +269,7 @@ export const DictionaryPage: FC<DictionaryProps> = () => {
           <div className={classes.sideGrid}>
             <GroupSelector
               group={group}
-              isOpacity={scroll > 200}
+              isOpacity={isGroupSelectorHidden}
               onGroupChange={onGroupChange}
             />
           </div>

--- a/src/modules/TextBookPage/TextBookPage.tsx
+++ b/src/modules/TextBookPage/TextBookPage.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { StateTextBook, Word } from 'types';
 import { Container } from '@material-ui/core';
-import { LocStore } from 'services';
 import {
   ErrorMessage,
   Loader,
@@ -16,6 +15,8 @@ import {
   PAGES_IN_EACH_GROUP,
   WordsSource,
 } from 'appConstants';
+import { LocStore } from 'services';
+import { useIsPageTopMatch } from 'hooks/useIsPageTopMatch';
 import { setPageTitle } from 'store/commonState/actions';
 import { GroupSelector } from 'components/GroupSelector';
 import {
@@ -58,7 +59,7 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
   const userId = useSelector(selectUserId);
   const isLoading = useSelector(selectIsLoading);
   const isUserLoading = useSelector(selectAuthLoadingStatus);
-  const [scroll, setScroll] = useState(0);
+  const isGroupSelectorHidden = useIsPageTopMatch(200);
   const [gettingGameWords, setGettingGameWords] = useState(false);
   const [checkPageForGameWords, setCheckPageForGameWords] = useState(-1);
   const [checkGroupForGameWords, setCheckGroupForGameWords] = useState(-1);
@@ -158,27 +159,6 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
     noMoreGameWords,
   ]);
 
-  useEffect(() => {
-    let lastKnownScrollPosition = scroll;
-    let ticking = false;
-
-    const handlerScroll = () => {
-      lastKnownScrollPosition = window.scrollY;
-      if (!ticking) {
-        window.requestAnimationFrame(() => {
-          setScroll(lastKnownScrollPosition);
-          ticking = false;
-        });
-        ticking = true;
-      }
-    };
-
-    window.addEventListener('scroll', handlerScroll);
-    return () => {
-      window.removeEventListener('scroll', handlerScroll);
-    };
-  }, [scroll]);
-
   const classes = useStyles();
 
   const hasContent = words && words.length;
@@ -220,7 +200,7 @@ export const TextBookPage: FC<TextBookPageProps> = () => {
             <div className={classes.sideGrid}>
               <GroupSelector
                 group={group}
-                isOpacity={scroll > 200}
+                isOpacity={isGroupSelectorHidden}
                 onGroupChange={onGroupChange}
               />
             </div>


### PR DESCRIPTION
Closes: #127 

Было повешено событие на скролл, которое постоянно рендерило учебник и словарь при скролле, поэтому вынесла расчет позиции в хук и сделала чтобы на маленьких экранах, когда компонент уже статический, его прозрачность не изменялась