### PR TITLE
RSL-70 Fix mobile menu

### DIFF
--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { MOBILE_WIDTH } from 'appConstants';
 
 export const useIsMobile = () => {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(window.innerWidth < MOBILE_WIDTH);
 
   useEffect(() => {
     const callback = () => {


### PR DESCRIPTION
Значение isMobile рассчитывалось только при изменении размера экрана, из-за чего, если сразу открыть с мобильного, оно отрабатывало неправильно.